### PR TITLE
Store `osm_id`

### DIFF
--- a/src/field/Locator.vue
+++ b/src/field/Locator.vue
@@ -312,6 +312,7 @@ export default {
                     'country': null,
                     'postcode': null,
                     'address': null,
+                    'osm': null,
                 }
 
                 if(this.saveZoom) {
@@ -373,7 +374,8 @@ export default {
                 'city': response.address.city || response.address.town || response.address.village || response.address.county || response.address.state,
                 'country': response.address.country,
                 'postcode': response.address.postcode,
-                'address': response.address.road
+                'address': response.address.road,
+                'osm': response.osm_id
             }
             if(this.saveZoom) {
                 this.value = {


### PR DESCRIPTION
Hey there,
this is somewhat related to #44, because saving a node's `osm_id` (which is already part of the response data) allows to retrieve the OSM link like that: `https://www.openstreetmap.org/node/OSM_ID`.

Please consider storing this piece of information, otherwise I'll have to send a duplicate request to get the ID, which would be unnecessary. Please let me know what you think, or how to improve my PR so you might consider merging it.

Cheers, and thank you for this plugin
S1SYPHOS